### PR TITLE
Advance last-written-LSN also on relation truncation.

### DIFF
--- a/src/test/regress/expected/zenith-rel-truncate.out
+++ b/src/test/regress/expected/zenith-rel-truncate.out
@@ -1,0 +1,19 @@
+--
+-- Test that when a relation is truncated by VACUUM, the next smgrnblocks()
+-- query to get the relation's size returns the new size.
+-- (This isn't related to the TRUNCATE command, which works differently,
+-- by creating a new relation file)
+--
+CREATE TABLE truncatetest (i int);
+INSERT INTO truncatetest SELECT g FROM generate_series(1, 10000) g;
+-- Remove all the rows, and run VACUUM to remove the dead tuples and
+-- truncate the physical relation to 0 blocks.
+DELETE FROM truncatetest;
+VACUUM truncatetest;
+-- Check that a SeqScan sees correct relation size (which is now 0)
+SELECT * FROM truncatetest;
+ i 
+---
+(0 rows)
+
+DROP TABLE truncatetest;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -6,6 +6,7 @@
 # ----------
 
 test: zenith-cid
+test: zenith-rel-truncate
 
 # run tablespace by itself, and first, because it forces a checkpoint;
 # we'd prefer not to have checkpoints later in the tests because that

--- a/src/test/regress/sql/zenith-rel-truncate.sql
+++ b/src/test/regress/sql/zenith-rel-truncate.sql
@@ -1,0 +1,18 @@
+--
+-- Test that when a relation is truncated by VACUUM, the next smgrnblocks()
+-- query to get the relation's size returns the new size.
+-- (This isn't related to the TRUNCATE command, which works differently,
+-- by creating a new relation file)
+--
+CREATE TABLE truncatetest (i int);
+INSERT INTO truncatetest SELECT g FROM generate_series(1, 10000) g;
+
+-- Remove all the rows, and run VACUUM to remove the dead tuples and
+-- truncate the physical relation to 0 blocks.
+DELETE FROM truncatetest;
+VACUUM truncatetest;
+
+-- Check that a SeqScan sees correct relation size (which is now 0)
+SELECT * FROM truncatetest;
+
+DROP TABLE truncatetest;


### PR DESCRIPTION
When a relation is truncated, we drop the dirty buffers of the truncated
portion from the buffer cache without writing them out. Because of that,
the last-written-LSN is not advanced on truncate. This scenario can
happen:

1. Some tuples on a page are deleted, with WAL record LSN N
2. The deleting transaction commits, vacuum runs, and the dead tuples are
   removed.
3. Vacuum truncates away the page, WAL-logged with LSN N+1
4. A sequential scan on the page calls smgrnblocks() to get the size of
   the relation. This uses N-1 as the request LSN of the "get relation
   size" call to the page server. Because the truncation happened at
   LSN N+1, the page server returns the old size before the truncation.
5. The sequential scan calls GetPage@LSN on the page, still with LSN-1
   as the request LSN. It gets the old page version, where the tuples
   have not been marked as deleted yet.

To fix, advance the last-written LSN also when a relation is truncated.

I think this bug explains the symptoms we're seeing at
https://github.com/zenithdb/zenith/issues/78.