### PR TITLE
Add debugging option to compare pages from local disk and page server.

### DIFF
--- a/src/backend/access/common/bufmask.c
+++ b/src/backend/access/common/bufmask.c
@@ -54,6 +54,8 @@ mask_page_hint_bits(Page page)
 	PageClearFull(page);
 	PageClearHasFreeLinePointers(page);
 
+	phdr->pd_flags &= ~PD_WAL_LOGGED;
+
 	/*
 	 * During replay, if the page LSN has advanced past our XLOG record's LSN,
 	 * we don't mark the page all-visible. See heap_xlog_visible() for


### PR DESCRIPTION
The first commit in this PR is same as https://github.com/zenithdb/postgres/pull/41. Ignore that here. The point of this PR is the second patch, to add the `DEBUG_COMPARE_LOCAL` debugging aid.