### PR TITLE
Update obsolete comments in zenith_wallog_page(). Fix...

### DIFF
--- a/src/backend/access/heap/vacuumlazy.c
+++ b/src/backend/access/heap/vacuumlazy.c
@@ -1603,7 +1603,10 @@ lazy_scan_heap(Relation onerel, VacuumParams *params, LVRelStats *vacrelstats,
 		else if (all_visible_according_to_vm && !PageIsAllVisible(page)
 				 && VM_ALL_VISIBLE(onerel, blkno, &vmbuffer))
 		{
-			elog(WARNING, "page is not marked all-visible but visibility map bit is set in relation \"%s\" page %u",
+			/* ZENITH-XXX: all visible hint is not wal-logged
+			 * FIXME: Replay visibilitymap changes in pageserver
+			 */
+			elog(DEBUG1, "page is not marked all-visible but visibility map bit is set in relation \"%s\" page %u",
 				 vacrelstats->relname, blkno);
 			visibilitymap_clear(onerel, blkno, vmbuffer,
 								VISIBILITYMAP_VALID_BITS);

--- a/src/backend/access/heap/vacuumlazy.c
+++ b/src/backend/access/heap/vacuumlazy.c
@@ -1603,8 +1603,7 @@ lazy_scan_heap(Relation onerel, VacuumParams *params, LVRelStats *vacrelstats,
 		else if (all_visible_according_to_vm && !PageIsAllVisible(page)
 				 && VM_ALL_VISIBLE(onerel, blkno, &vmbuffer))
 		{
-			/* ZENITH-XXX: all visible hint is not wal-logged */
-			elog(DEBUG1, "page is not marked all-visible but visibility map bit is set in relation \"%s\" page %u",
+			elog(WARNING, "page is not marked all-visible but visibility map bit is set in relation \"%s\" page %u",
 				 vacrelstats->relname, blkno);
 			visibilitymap_clear(onerel, blkno, vmbuffer,
 								VISIBILITYMAP_VALID_BITS);

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -1181,6 +1181,7 @@ log_newpage_range(Relation rel, ForkNumber forkNum,
 			MarkBufferDirty(bufpack[i]);
 		}
 
+		//Zenith XXX: What's the purpose of this change?
 		if (nbufs > 0)
 			recptr = XLogInsert(RM_XLOG_ID, XLOG_FPI);
 		else

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -1181,7 +1181,14 @@ log_newpage_range(Relation rel, ForkNumber forkNum,
 			MarkBufferDirty(bufpack[i]);
 		}
 
-		//Zenith XXX: What's the purpose of this change?
+		/*
+		 * Zenith forces WAL logging of evicted pages,
+		 * so it can happen that in some cases when pages are first
+		 * modified and then WAL logged (for example building GiST/GiN
+		 * indexes) there are no more pages which need to be WAL logged at
+		 * the end of build procedure. As far as XLogInsert throws error
+		 * if not records were inserted, we need to reset the insert state.
+		 */
 		if (nbufs > 0)
 			recptr = XLogInsert(RM_XLOG_ID, XLOG_FPI);
 		else

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -3922,6 +3922,13 @@ MarkBufferDirtyHint(Buffer buffer, bool buffer_std)
 		}
 
 		buf_state |= BM_DIRTY | BM_JUST_DIRTIED;
+
+		/* Zenith XXX
+		 * Mark this page as not WAL-logged,
+		 * so that pagestore_smgr issued a log record before eviction.
+		 */
+		((PageHeader)page)->pd_flags &= ~PD_WAL_LOGGED;
+
 		UnlockBufHdr(bufHdr, buf_state);
 
 		if (delayChkpt)

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -3924,10 +3924,13 @@ MarkBufferDirtyHint(Buffer buffer, bool buffer_std)
 		buf_state |= BM_DIRTY | BM_JUST_DIRTIED;
 
 		/* Zenith XXX
-		 * Mark this page as not WAL-logged,
-		 * so that pagestore_smgr issued a log record before eviction.
+		 * Consider marking this page as not WAL-logged,
+		 * so that pagestore_smgr issued a log record before eviction
+		 * and persisted hint changes.
+		 * TODO: check performance impacts of this approach
+		 * since extra wal-logging may worsen the performance.
 		 */
-		((PageHeader)page)->pd_flags &= ~PD_WAL_LOGGED;
+		//((PageHeader)page)->pd_flags &= ~PD_WAL_LOGGED;
 
 		UnlockBufHdr(bufHdr, buf_state);
 

--- a/src/include/storage/bufpage.h
+++ b/src/include/storage/bufpage.h
@@ -181,16 +181,25 @@ typedef PageHeaderData *PageHeader;
 #define PD_PAGE_FULL		0x0002	/* not enough free space for new tuple? */
 #define PD_ALL_VISIBLE		0x0004	/* all tuples on page are visible to
 									 * everyone */
+
+/* Zenith XXX:
+ * Some operations in PostgreSQL are not WAL-logged at all (i.e. hint bits)
+ * or delay wal-logging till the end of operation (i.e. index build).
+ *
+ * So if such page is evicted, we will lose the update.
+ * To fix it, we introduce PD_WAL_LOGGED bit to track whether the page was wal-logged.
+ * If page is evicted before it has been wal-logged, then pagestore_smgr creates FPI for it.
+ *
+ * List of such operations:
+ * - GIN/GiST/SP-GiST index build
+ * - page and heaptuple hint bits
+ * - Clearing visibility map bits
+ * - FSM changes
+ * - ???
+ */
 #define PD_WAL_LOGGED       0x0008  /* Page is wal-logged */
 #define PD_VALID_FLAG_BITS	0x000F	/* OR of all valid pd_flags bits */
 
-/* Zenith XXX: build of gist, spgist and gin indexes first construct all index pages and only
- * then wal log them. So if page is evicted before, we will loose the update.
- * This is why PG_UNLOGGED bit was introduced. It is set when gist/spgist or gin page is initialized,
- * and is cleared when page is wal logged.
- * If page is written to the disk before been wal-logged, then pagestore_smgr
- * creates FPI for it.
- */
 
 /*
  * Page layout version number 0 is for pre-7.3 Postgres releases.


### PR DESCRIPTION
Fix treatment of pages with non-standard layout (VM, FSM).