### PR TITLE
Simplify WL_LATCH_SET testing in the walproposer

### DIFF
--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -876,7 +876,7 @@ WalProposerPoll(void)
 		 * each wal flush), then exit loop. (no need for pm death check due to
 		 * WL_EXIT_ON_PM_DEATH)
 		 */
-		if (event.events & (WL_LATCH_SET) != 0)
+		if (event.events & WL_LATCH_SET)
 		{
 			ResetLatch(MyLatch);
 			break;


### PR DESCRIPTION
Clang complains on this WL_LATCH_SET testing:

```c
src/backend/replication/walproposer.c:879:20: warning: & has lower precedence than !=; != will be evaluated first [-Wparentheses]
                if (event.events & (WL_LATCH_SET) != 0)
                                 ^~~~~~~~~~~~~~~~~~~~~
src/backend/replication/walproposer.c:879:20: note: place parentheses around the '!=' expression to silence this warning
                if (event.events & (WL_LATCH_SET) != 0)
                                 ^
                                   (                  )
src/backend/replication/walproposer.c:879:20: note: place parentheses around the & expression to evaluate it first
                if (event.events & (WL_LATCH_SET) != 0)
                                 ^
                    (                            )
1 warning generated.
```

If `!=` is always evaluated first then it gives us `true` or `1`, since `WL_LATCH_SET = 1 << 0`. And it becomes just a `event.events & 1`. So logically it is the same as `event.events & WL_LATCH_SET`, but why is it that complicated? I propose this fix, or maybe I missed something?