### PR TITLE
Fix some bugs in seccomp bpf wrapper

### DIFF
--- a/src/backend/tcop/zenith_wal_redo.c
+++ b/src/backend/tcop/zenith_wal_redo.c
@@ -109,6 +109,7 @@ enter_seccomp_mode(void)
 		PG_SCMP_ALLOW(exit_group),
 		PG_SCMP_ALLOW(pselect6),
 		PG_SCMP_ALLOW(read),
+		PG_SCMP_ALLOW(select),
 		PG_SCMP_ALLOW(write),
 
 		/* Memory allocation */


### PR DESCRIPTION
* Use SCMP_ACT_TRAP instead of SCMP_ACT_KILL_PROCESS to receive signals.
* Add a missing variant of select() syscall (thx to @knizhnik).
* Write error messages to an fd stderr's currently pointing to.