### PR TITLE
support zenith_tenant

### DIFF
--- a/contrib/zenith/pagestore_client.h
+++ b/contrib/zenith/pagestore_client.h
@@ -90,6 +90,7 @@ extern page_server_api * page_server;
 extern char *page_server_connstring;
 extern char *callmemaybe_connstring;
 extern char *zenith_timeline;
+extern char *zenith_tenant;
 extern bool wal_redo;
 
 extern const f_smgr *smgr_zenith(BackendId backend, RelFileNode rnode);

--- a/contrib/zenith/pagestore_smgr.c
+++ b/contrib/zenith/pagestore_smgr.c
@@ -56,6 +56,7 @@ page_server_api *page_server;
 char *page_server_connstring;
 char *callmemaybe_connstring;
 char *zenith_timeline;
+char *zenith_tenant;
 bool wal_redo = false;
 
 char const *const ZenithMessageStr[] =

--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -221,6 +221,7 @@ HandleWalKeeperResponse(void)
 }
 
 char *zenith_timeline_walproposer = NULL;
+char *zenith_tenant_walproposer = NULL;
 
 /*
  * WAL proposer bgworeker entry point
@@ -285,6 +286,13 @@ WalProposerMain(Datum main_arg)
 	if (*zenith_timeline_walproposer != '\0' &&
 	 !HexDecodeString(serverInfo.ztimelineid, zenith_timeline_walproposer, 16))
 		elog(FATAL, "Could not parse zenith.zenith_timeline, %s", zenith_timeline_walproposer);
+	
+	if (!zenith_tenant_walproposer)
+		elog(FATAL, "zenith.zenith_tenant is not provided");
+	if (*zenith_tenant_walproposer != '\0' &&
+	 !HexDecodeString(serverInfo.ztenantid, zenith_tenant_walproposer, 16))
+		elog(FATAL, "Could not parse zenith.zenith_tenant, %s", zenith_tenant_walproposer);
+
 	serverInfo.protocolVersion = SK_PROTOCOL_VERSION;
 	pg_strong_random(&serverInfo.nodeId.uuid, sizeof(serverInfo.nodeId.uuid));
 	serverInfo.systemId = GetSystemIdentifier();

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -23,6 +23,7 @@ struct WalMessage;
 typedef struct WalMessage WalMessage;
 
 extern char *zenith_timeline_walproposer;
+extern char *zenith_tenant_walproposer;
 
 /* WAL safekeeper state */
 typedef enum
@@ -59,6 +60,7 @@ typedef struct ServerInfo
 	XLogRecPtr walEnd;
     TimeLineID timeline;
 	int        walSegSize;
+	uint8      ztenantid[16];
 } ServerInfo;
 
 /*


### PR DESCRIPTION
this patch adds support for zenith_tenant variable. it has similar
format as zenith_timeline. It is used in callmemaybe query to pass
tenant to pageserver and in ServerInfo structure passed to wal acceptor

corresponding pr to zenith https://github.com/zenithdb/zenith/pull/318