### PR TITLE
Remove graceful termination of COPY during walproposer recovery.

### DIFF
--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -612,7 +612,6 @@ WalProposerRecovery(int leader, TimeLineID timeline, XLogRecPtr startpos, XLogRe
 			if (rec_end_lsn >= endpos)
 				break;
 		}
-		walrcv_endstreaming(wrconn, &timeline);
 		walrcv_disconnect(wrconn);
 	}
 	else


### PR DESCRIPTION
Rust's postgres_backend currently is too dummy to handle it properly: reading
happens in separate thread which just ignores CopyDone. Instead, writer thread
must get aware of termination and send CommandComplete. Also reading socket must
be transferred back to postgres_backend (or connection terminated completely
after COPY). Let's do that after more basic safkeeper refactoring and right now
cover this up to make tests pass.

ref #388