### PR TITLE
Add --sync-walkeepers options allowing to start walproposer without PGDATA to sync safekeepers

### DIFF
--- a/src/backend/main/main.c
+++ b/src/backend/main/main.c
@@ -35,6 +35,7 @@
 #include "common/username.h"
 #include "port/atomics.h"
 #include "postmaster/postmaster.h"
+#include "replication/walproposer.h"
 #include "storage/spin.h"
 #include "tcop/tcopprot.h"
 #include "utils/help_config.h"
@@ -209,6 +210,8 @@ main(int argc, char *argv[])
 		WalRedoMain(argc, argv,
 					 NULL,		/* no dbname */
 					 strdup(get_user_name_or_exit(progname)));	/* does not return */
+	else if (argc > 1 && strcmp(argv[1], "--sync-safekeepers") == 0)
+		WalProposerSync(argc, argv);
 	else
 		PostmasterMain(argc, argv); /* does not return */
 	abort();					/* should not get here */

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -244,7 +244,7 @@ typedef struct AppendRequestHeader
 	XLogRecPtr commitLsn;   /* LSN committed by quorum of walkeepers */
 	/*
 	 *  minimal LSN which may be needed for recovery of some safekeeper (end lsn
-	 *  + 1 of last record streamed to everyone)
+	 *  + 1 of last chunk streamed to everyone)
 	 */
     XLogRecPtr truncateLsn;
     pg_uuid_t  proposerId; /* for monitoring/debugging */
@@ -289,8 +289,11 @@ typedef struct AppendResponse
 	 */
 	uint64 tag;
 	term_t     term;
-	term_t     epoch;
+	term_t epoch;
 	XLogRecPtr flushLsn;
+	// Safekeeper reports back his awareness about which WAL is committed, as
+	// this is a criterion for walproposer --sync mode exit
+	XLogRecPtr commitLsn;
 	HotStandbyFeedback hs;
 } AppendResponse;
 
@@ -344,6 +347,8 @@ void       ProcessStandbyHSFeedback(TimestampTz   replyTime,
 									TransactionId feedbackCatalogXmin,
 									uint32		feedbackCatalogEpoch);
 void       StartReplication(StartReplicationCmd *cmd);
+void       WalProposerSync(int argc, char *argv[]);
+
 
 /* libpqwalproposer hooks & helper type */
 


### PR DESCRIPTION
Fix for https://github.com/zenithdb/zenith/issues/439