### PR TITLE
Ask pageserver only with LSN's aligned on record boundary.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7889,6 +7889,7 @@ StartupXLOG(void)
 
 	XLogCtl->LogwrtRqst.Write = EndOfLog;
 	XLogCtl->LogwrtRqst.Flush = EndOfLog;
+	XLogCtl->lastWrittenPageLSN = EndOfLog;
 
 	/*
 	 * Update full_page_writes in shared memory and write an XLOG_FPW_CHANGE


### PR DESCRIPTION
Now pageserver tracks only last_record_lsn and ignores
last_valids_lsn. We can cause deadlock at start or extreme slowness
during the normal work if we call get_page with LSN of incomplete
record.

Patch by @knizhnik