### PR TITLE
Fix compiler warnings in walproposer.c

### DIFF
--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -316,8 +316,7 @@ HandleWalKeeperResponse(void)
 {
 	HotStandbyFeedback hsFeedback;
 	XLogRecPtr minQuorumLsn;
-	int i;
-	int n_synced;
+	int n_synced = 0;
 
 	minQuorumLsn = GetAcknowledgedByQuorumWALPosition();
 	if (minQuorumLsn > lastFeedback.flushLsn)


### PR DESCRIPTION
On macos with clang I have following warnings:

```
/Users/alexk/dev/pg/tmp/../postgres/src/backend/replication/walproposer.c:319:6: warning: unused variable 'i' [-Wunused-variable]
        int i;
            ^
/Users/alexk/dev/pg/tmp/../postgres/src/backend/replication/walproposer.c:382:5: warning: variable 'n_synced' is uninitialized when used here [-Wuninitialized]
                                n_synced++;
                                ^~~~~~~~
/Users/alexk/dev/pg/tmp/../postgres/src/backend/replication/walproposer.c:320:14: note: initialize the variable 'n_synced' to silence this warning
        int n_synced;
                    ^
                     = 0
```

Probably this is already fixed in one of ongoing PRs, then we can close this one.