### PR TITLE
Mark all recovery messages as received by the donor.

### DIFF
--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -224,8 +224,6 @@ ResetConnection(int i)
 
 	if (wk->state != SS_OFFLINE)
 	{
-		elog(WARNING, "Connection with node %s:%s in %s state failed",
-			wk->host, wk->port, FormatWalKeeperState(wk->state));
 		ShutdownConnection(i);
 	}
 
@@ -1187,9 +1185,10 @@ AdvancePollState(int i, uint32 events)
 			 * execution of SS_HANDSHAKE_RECV to see how nodes are transferred from SS_VOTING to
 			 * SS_SEND_VOTE. */
 			case SS_VOTING:
-				elog(FATAL, "Unexpected walkeeper %s:%s state advancement: is voting",
-					 wk->host, wk->port);
-				break; /* actually unreachable, but prevents -Wimplicit-fallthrough */
+				elog(WARNING, "EOF from node %s:%s in %s state", wk->host,
+					 wk->port, FormatWalKeeperState(wk->state));
+				ResetConnection(i);
+				break;
 
 			/* We have quorum for voting, send our vote request */
 			case SS_SEND_VOTE:
@@ -1276,8 +1275,10 @@ AdvancePollState(int i, uint32 events)
 			/* Idle state for sending WAL. Moved out only by calls to
 			 * SendMessageToNode */
 			case SS_IDLE:
-				elog(FATAL, "Unexpected walkeeper %s:%s state advancement: is idle", wk->host, wk->port);
-				break; /* actually unreachable, but prevents -Wimplicit-fallthrough */
+				elog(WARNING, "EOF from node %s:%s in %s state", wk->host,
+					 wk->port, FormatWalKeeperState(wk->state));
+				ResetConnection(i);
+				break;
 
 			/* Start to send the message at wk->currMsg. Triggered only by calls
 			 * to SendMessageToNode */

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -259,6 +259,12 @@ struct WalMessage
 	WalMessage* next;      /* L1 list of messages */
 	uint32 size;           /* message size */
 	uint32 ackMask;        /* mask of receivers acknowledged receiving of this message */
+	/*
+	 * By convention safekeeper starts receiving data since record boundary, we
+	 * may need to send first message not from the chunk beginning for that;
+	 * such trimmed message is formed here.
+	 */
+	AppendRequestHeader *perSafekeeper[MAX_WALKEEPERS];
 	AppendRequestHeader req; /* request to walkeeper (message header) */
 
 	/* PHANTOM FIELD:


### PR DESCRIPTION
I forgot to do that in 42316a81d3. Fixes segfault related to attempt to send the
(garbage collected) message second time and queue advancement when donor doesn't
restart.