### PR TITLE
Fix truncateLsn update

### DIFF
--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -73,7 +73,6 @@ static XLogRecPtr lastSentLsn;	/* WAL has been appended to msg queue up to
 								 * this point */
 static XLogRecPtr lastSentCommitLsn;	/* last commitLsn broadcast to
 										 * walkeepers */
-static XLogRecPtr acknowledgedLsn; /* LSN acknowledged by all walkeepers */
 static ProposerGreeting proposerGreeting;
 static WaitEventSet *waitEvents;
 static AppendResponse lastFeedback;
@@ -160,10 +159,12 @@ CalculateMinFlushLsn(void)
 	XLogRecPtr lsn = UnknownXLogRecPtr;
 	for (int i = 0; i < n_walkeepers; i++)
 	{
+		/* We can't rely on safekeeper flushLsn if it has wrong epoch */
+		if (walkeeper[i].feedback.epoch != propTerm)
+			return 0;
+
 		if (walkeeper[i].feedback.flushLsn < lsn)
-		{
 			lsn = walkeeper[i].feedback.flushLsn;
-		}
 	}
 	return lsn;
 }
@@ -423,7 +424,7 @@ HandleWalKeeperResponse(void)
 	 * ack only on record boundaries.
 	 */
 	minFlushLsn = CalculateMinFlushLsn();
-	if (minFlushLsn > truncateLsn && minFlushLsn <= minQuorumLsn && minFlushLsn <= acknowledgedLsn)
+	if (minFlushLsn > truncateLsn)
 		truncateLsn = minFlushLsn;
 
 	/* Cleanup message queue up to truncateLsn, but only messages received by everyone */
@@ -1591,15 +1592,6 @@ AdvancePollState(int i, uint32 events)
 					wk->currMsg->ackMask |= 1 << i; /* this walkeeper confirms
 													 * receiving of this
 													 * message */
-
-					/* If the current message was received by all safekeepers,
-					 * update acknowledgedLsn.
-					 */
-					if (wk->currMsg->ackMask == ((1 << n_walkeepers) - 1))
-					{
-						Assert(wk->currMsg->req.endLsn >= acknowledgedLsn);
-						acknowledgedLsn = wk->currMsg->req.endLsn;
-					}
 
 					wk->currMsg = NULL;
 					HandleWalKeeperResponse();


### PR DESCRIPTION
There was a bug when candidateTruncateLsn was distant from truncateLsn and a lot of CPU time was spent in HandleWalKeeperResponse trying to advance truncateLsn. This PR fixes this by changing logic to update truncateLsn, using `Min(walkeeper[i].feedback.flushLsn)` as a candidate for new truncateLsn.