### PR TITLE
Forward pageserver addr to safekeeper

### DIFF
--- a/contrib/zenith/pagestore_smgr.c
+++ b/contrib/zenith/pagestore_smgr.c
@@ -86,7 +86,7 @@ const int	SmgrTrace = DEBUG5;
 page_server_api *page_server;
 
 /* GUCs */
-char	   *page_server_connstring;
+char	   *page_server_connstring; // with substituted password
 char	   *callmemaybe_connstring;
 char	   *zenith_timeline;
 char	   *zenith_tenant;

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -36,6 +36,7 @@ typedef struct WalMessage WalMessage;
 
 extern char *zenith_timeline_walproposer;
 extern char *zenith_tenant_walproposer;
+extern char	*zenith_pageserver_connstring_walproposer;
 
 /* Possible return values from ReadPGAsync */
 typedef enum


### PR DESCRIPTION
This is needed for implementation of tenant rebalancing. With this
change safekeeper becomes aware of which pageserver is supposed to be
used for replication from this compute.

This also changes logic of substitution of auth token inside the
connection string. So it is substituted during config variable
parsing and available for both, smgr pageserver connection and
walproposer safekeeper connection.

Corresponding zenith PR: https://github.com/zenithdb/zenith/pull/939