### PR TITLE
[walproposer] Async WAL append

### DIFF
--- a/src/backend/replication/libpqwalproposer/libpqwalproposer.c
+++ b/src/backend/replication/libpqwalproposer/libpqwalproposer.c
@@ -22,7 +22,7 @@ static WalProposerConnectPollStatusType	libpqprop_connect_poll(WalProposerConn* 
 static bool								libpqprop_send_query(WalProposerConn* conn, char* query);
 static WalProposerExecStatusType		libpqprop_get_query_result(WalProposerConn* conn);
 static pgsocket							libpqprop_socket(WalProposerConn* conn);
-static int								libpqprop_flush(WalProposerConn* conn, bool socket_read_ready);
+static int								libpqprop_flush(WalProposerConn* conn);
 static void								libpqprop_finish(WalProposerConn* conn);
 static PGAsyncReadResult				libpqprop_async_read(WalProposerConn* conn, char** buf, int* amount);
 static PGAsyncWriteResult				libpqprop_async_write(WalProposerConn* conn, void const* buf, size_t size);
@@ -239,13 +239,8 @@ libpqprop_socket(WalProposerConn* conn)
 }
 
 static int
-libpqprop_flush(WalProposerConn* conn, bool socket_read_ready)
+libpqprop_flush(WalProposerConn* conn)
 {
-	/* If the socket is read-ready, we have to call PQconsumeInput before
-	 * calling PQflush (according to libpq docs) */
-	if (socket_read_ready && !PQconsumeInput(conn->pg_conn))
-		return -1; /* return failure if PQconsumeInput fails */
-
 	return (PQflush(conn->pg_conn));
 }
 

--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -1328,8 +1328,10 @@ SendAppendRequests(WalKeeper *wk, uint32 events)
 }
 
 /*
- * Receive and process all available feedback. Can change state if Async* functions
- * encounter errors and reset connection.
+ * Receive and process all available feedback.
+ *
+ * Can change state if Async* functions encounter errors and reset connection.
+ * Returns false in this case, true otherwise.
  * 
  * NB: This function can call SendMessageToNode and produce new messages.
  */

--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -707,6 +707,9 @@ WalProposerStartStreaming(XLogRecPtr startpos)
 
 /*
  * Start sending message to the particular node.
+ *
+ * Always updates the state and event set for the WAL keeper; setting either of
+ * these before calling would be redundant work.
  */
 static void
 SendMessageToNode(int i, WalMessage *msg)

--- a/src/backend/replication/walproposer_utils.c
+++ b/src/backend/replication/walproposer_utils.c
@@ -75,14 +75,8 @@ FormatWalKeeperState(WalKeeperState state)
 		case SS_IDLE:
 			return_val = "idle";
 			break;
-		case SS_SEND_WAL:
-			return_val = "WAL-sending";
-			break;
-		case SS_SEND_WAL_FLUSH:
-			return_val = "WAL-sending (flushing)";
-			break;
-		case SS_RECV_FEEDBACK:
-			return_val = "WAL-feedback-receiving";
+		case SS_ACTIVE_STATE:
+			return_val = "WAL-active-state";
 			break;
 	}
 
@@ -143,7 +137,6 @@ WalKeeperStateDesiredEvents(WalKeeperState state)
 		case SS_WAIT_EXEC_RESULT:
 		case SS_HANDSHAKE_RECV:
 		case SS_WAIT_VERDICT:
-		case SS_RECV_FEEDBACK:
 			result = WL_SOCKET_READABLE;
 			break;
 
@@ -151,12 +144,11 @@ WalKeeperStateDesiredEvents(WalKeeperState state)
 		case SS_EXEC_STARTWALPUSH:
 		case SS_HANDSHAKE_SEND:
 		case SS_SEND_VOTE:
-		case SS_SEND_WAL:
 			result = WL_NO_EVENTS;
 			break;
 		/* but flushing does require read- or write-ready */
 		case SS_SEND_ELECTED_FLUSH:
-		case SS_SEND_WAL_FLUSH:
+		case SS_ACTIVE_STATE:
 			result = WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE;
 			break;
 

--- a/src/backend/replication/walproposer_utils.c
+++ b/src/backend/replication/walproposer_utils.c
@@ -75,8 +75,8 @@ FormatWalKeeperState(WalKeeperState state)
 		case SS_IDLE:
 			return_val = "idle";
 			break;
-		case SS_ACTIVE_STATE:
-			return_val = "WAL-active-state";
+		case SS_ACTIVE:
+			return_val = "active";
 			break;
 	}
 
@@ -148,7 +148,8 @@ WalKeeperStateDesiredEvents(WalKeeperState state)
 			break;
 		/* but flushing does require read- or write-ready */
 		case SS_SEND_ELECTED_FLUSH:
-		case SS_ACTIVE_STATE:
+		/* Active state does both reading and writing to the socket */
+		case SS_ACTIVE:
 			result = WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE;
 			break;
 

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -159,25 +159,32 @@ typedef enum
 	 * Moves to SS_SEND_WAL only by calls to SendMessageToNode.
 	 */
 	SS_IDLE,
+
+
 	/*
-	 * Start sending the message at currMsg. This state is only ever reached
-	 * through calls to SendMessageToNode.
-	 *
-	 * Sending needs to flush; immediately moves to SS_SEND_WAL_FLUSH.
+	 * Sending WAL to the node, receiving feedback from the node.
 	 */
-	SS_SEND_WAL,
-	/*
-	 * Flush the WAL message, repeated until successful. On success, moves to
-	 * SS_RECV_FEEDBACK.
-	 */
-	SS_SEND_WAL_FLUSH,
-	/*
-	 * Currently reading feedback from sending the WAL.
-	 *
-	 * After reading, moves to (SS_SEND_WAL or SS_IDLE) by calls to
-	 * SendMessageToNode.
-	 */
-	SS_RECV_FEEDBACK,
+	SS_ACTIVE_STATE,
+
+	// /*
+	//  * Start sending the message at currMsg. This state is only ever reached
+	//  * through calls to SendMessageToNode.
+	//  *
+	//  * Sending needs to flush; immediately moves to SS_SEND_WAL_FLUSH.
+	//  */
+	// SS_SEND_WAL,
+	// /*
+	//  * Flush the WAL message, repeated until successful. On success, moves to
+	//  * SS_RECV_FEEDBACK.
+	//  */
+	// SS_SEND_WAL_FLUSH,
+	// /*
+	//  * Currently reading feedback from sending the WAL.
+	//  *
+	//  * After reading, moves to (SS_SEND_WAL or SS_IDLE) by calls to
+	//  * SendMessageToNode.
+	//  */
+	// SS_RECV_FEEDBACK,
 } WalKeeperState;
 
 /* Consensus logical timestamp. */
@@ -357,7 +364,9 @@ typedef struct WalKeeper
 	WalProposerConn*   conn;
 	StringInfoData outbuf;
 
-	WalMessage*        currMsg;       /* message been send to the receiver */
+	WalMessage*        currMsg;       /* message been send to the receiver, flushWrite==true means it's already sent, flushWrite==false means it should be sent */
+	WalMessage*        ackMsg;        /* message waiting ack from receiver */
+	bool			   flushWrite;    /* true if flush is required before write */
 
 	int                eventPos;      /* position in wait event set. Equal to -1 if no event */
 	WalKeeperState     state;         /* walkeeper state machine state */

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -456,7 +456,7 @@ typedef WalProposerExecStatusType (*walprop_get_query_result_fn) (WalProposerCon
 typedef pgsocket (*walprop_socket_fn) (WalProposerConn* conn);
 
 /* Wrapper around PQconsumeInput (if socket's read-ready) + PQflush */
-typedef int (*walprop_flush_fn) (WalProposerConn* conn, bool socket_read_ready);
+typedef int (*walprop_flush_fn) (WalProposerConn* conn);
 
 /* Re-exported PQfinish */
 typedef void (*walprop_finish_fn) (WalProposerConn* conn);
@@ -531,8 +531,8 @@ typedef struct WalProposerFunctionsType
 	WalProposerFunctions->walprop_set_nonblocking(conn, arg)
 #define walprop_socket(conn) \
 	WalProposerFunctions->walprop_socket(conn)
-#define walprop_flush(conn, consume_input) \
-	WalProposerFunctions->walprop_flush(conn, consume_input)
+#define walprop_flush(conn) \
+	WalProposerFunctions->walprop_flush(conn)
 #define walprop_finish(conn) \
 	WalProposerFunctions->walprop_finish(conn)
 #define walprop_async_read(conn, buf, amount) \

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -70,10 +70,7 @@ typedef enum
 /*
  * WAL safekeeper state
  *
- * States are listed here in the order that they're executed - with the only
- * exception occuring from the "send WAL" cycle, which loops as:
- *
- *   SS_IDLE -> SS_ACTIVE -> SS_IDLE
+ * States are listed here in the order that they're executed.
  *
  * Most states, upon failure, will move back to SS_OFFLINE by calls to
  * ResetConnection or ShutdownConnection.
@@ -163,8 +160,6 @@ typedef enum
 	/*
 	 * Active phase, when we acquired quorum and have WAL to send or feedback
 	 * to read.
-	 * 
-	 * Moves to SS_IDLE when we have nothing to do.
 	 */
 	SS_ACTIVE,
 } WalKeeperState;


### PR DESCRIPTION
Implement async wp <-> sk protocol, send WAL messages ahead of feedback replies.

New SS_ACTIVE state is introduced instead of former SS_SEND_WAL / SS_SEND_WAL_FLUSH / SS_RECV_FEEDBACK.