### PR TITLE
Fix walsender to work with zenith style standbyReply

### DIFF
--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -406,8 +406,7 @@ HandleWalKeeperResponse(void)
 		/* advance the replication slot */
 		if (!syncSafekeepers)
 			ProcessStandbyReply(
-								// write_lsn
-								// Not used, because we use SYNCHRONOUS_COMMIT_REMOTE_FLUSH.
+								// write_lsn -  This is what durably stored in WAL service.
 								lastFeedback.flushLsn,
 								//flush_lsn - This is what durably stored in WAL service.
 								lastFeedback.flushLsn,

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -2982,8 +2982,8 @@ WalSndDone(WalSndSendDataCallback send_data)
 	 * flush location if valid, write otherwise. Tools like pg_receivewal will
 	 * usually (unless in synchronous mode) return an invalid flush location.
 	 */
-	replicatedPtr = XLogRecPtrIsInvalid(MyWalSnd->flush) ?
-		MyWalSnd->write : MyWalSnd->flush;
+	// XXX Zenith uses flush_lsn to pass extra payload, so use write_lsn here
+	replicatedPtr = MyWalSnd->write;
 
 	if (WalSndCaughtUp && sentPtr == replicatedPtr &&
 		!pq_is_send_pending())
@@ -3795,12 +3795,14 @@ backpressure_lag(void)
 			LSN_FORMAT_ARGS(applyPtr));
 
 		if ((flushPtr != UnknownXLogRecPtr
+			&& max_replication_flush_lag > 0
 			&& myFlushLsn > flushPtr + max_replication_flush_lag*MB))
 		{
 			return (myFlushLsn - flushPtr - max_replication_flush_lag*MB);
 		}
 
 		if ((applyPtr != UnknownXLogRecPtr
+			&& max_replication_apply_lag > 0
 			&& myFlushLsn > applyPtr + max_replication_apply_lag*MB))
 		{
 			return (myFlushLsn - applyPtr - max_replication_apply_lag*MB);

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2907,7 +2907,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_MB,
 		},
 		&max_replication_apply_lag,
-		0, 0, INT_MAX, /* it should not be smaller than maximal size of WAL record */
+		-1, -1, INT_MAX, /* it should not be smaller than maximal size of WAL record */
 		NULL, NULL, NULL
 	},
 
@@ -2919,7 +2919,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_MB,
 		},
 		&max_replication_flush_lag,
-		0, 0, INT_MAX, /* it should not be smaller than maximal size of WAL record */
+		-1, -1, INT_MAX, /* it should not be smaller than maximal size of WAL record */
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
Fix walsender to work with zenith style standbyReply that sends non-zero flushLsn.

Clean up backpressure defaults.