### PR TITLE
Simplify walproposer code

### DIFF
--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -110,7 +110,15 @@ static void ShutdownConnection(WalKeeper *wk);
 static void ResetConnection(WalKeeper *wk);
 static long TimeToReconnect(TimestampTz now);
 static void ReconnectWalKeepers(void);
-static void AdvancePollState(int i, uint32 events);
+static void AdvancePollState(WalKeeper *wk, uint32 events);
+static void HandleConnectionEvent(WalKeeper *wk);
+static void SendStartWALPush(WalKeeper *wk);
+static void RecvStartWALPushResult(WalKeeper *wk);
+static void SendProposerGreeting(WalKeeper *wk);
+static void RecvAcceptorGreeting(WalKeeper *wk);
+static void SendVoteRequest(WalKeeper *wk);
+static void RecvVoteResponse(WalKeeper *wk);
+static void HandleElectedProposer(void);
 static term_t GetHighestTerm(TermHistory *th);
 static term_t GetEpoch(WalKeeper *wk);
 static void DetermineEpochStartLsn(void);
@@ -129,10 +137,10 @@ static XLogRecPtr CalculateDiskConsistentLsn(void);
 static XLogRecPtr CalculateMinFlushLsn(void);
 static XLogRecPtr GetAcknowledgedByQuorumWALPosition(void);
 static void HandleWalKeeperResponse(void);
-static bool AsyncRead(int i, char **buf, int *buf_size);
-static bool AsyncReadFixed(int i, void *value, size_t value_size);
-static bool AsyncReadMessage(int i, AcceptorProposerMessage *anymsg);
-static bool BlockingWrite(int i, void *msg, size_t msg_size, WalKeeperState success_state);
+static bool AsyncRead(WalKeeper *wk, char **buf, int *buf_size);
+static bool AsyncReadFixed(WalKeeper *wk, void *value, size_t value_size);
+static bool AsyncReadMessage(WalKeeper *wk, AcceptorProposerMessage *anymsg);
+static bool BlockingWrite(WalKeeper *wk, void *msg, size_t msg_size, WalKeeperState success_state);
 static bool AsyncWrite(WalKeeper *wk, void *msg, size_t msg_size, WalKeeperState flush_state);
 static bool AsyncFlush(WalKeeper *wk);
 
@@ -250,21 +258,19 @@ WalProposerPoll(void)
 	{
 		WalKeeper  *wk;
 		int			rc;
-		int			i;
 		WaitEvent	event;
 		TimestampTz now = GetCurrentTimestamp();
 
 		rc = WaitEventSetWait(waitEvents, TimeToReconnect(now),
 							  &event, 1, WAIT_EVENT_WAL_SENDER_MAIN);
 		wk = (WalKeeper *) event.user_data;
-		i = (int) (wk - walkeeper);
 
 		/*
 		 * If the event contains something that one of our walkeeper states
 		 * was waiting for, we'll advance its state.
 		 */
 		if (rc != 0 && (event.events & (WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE)))
-			AdvancePollState(i, event.events);
+			AdvancePollState(wk, event.events);
 
 		/*
 		 * If the timeout expired, attempt to reconnect to any walkeepers that
@@ -640,453 +646,452 @@ ReconnectWalKeepers(void)
 }
 
 /*
- * Performs the logic for advancing the state machine of the 'i'th walkeeper,
+ * Performs the logic for advancing the state machine of the specified walkeeper,
  * given that a certain set of events has occured.
  */
 static void
-AdvancePollState(int i, uint32 events)
+AdvancePollState(WalKeeper *wk, uint32 events)
 {
-	WalKeeper  *wk = &walkeeper[i];
 	/*
-	 * Keep advancing the state while either: (a) the event is still
-	 * unprocessed (usually because it's the first iteration of the loop), or
-	 * (b) the state can execute, and does not need to wait for any socket
-	 * events
+	 * Sanity check. We assume further down that the operations don't
+	 * block because the socket is ready.
 	 */
-	while (events || StateShouldImmediatelyExecute(wk->state))
+	AssertEventsOkForState(events, wk);
+
+	/* Execute the code corresponding to the current state */
+	switch (wk->state)
 	{
-		/*
-		 * Sanity check. We assume further down that the operations don't
-		 * block because the socket is ready.
-		 */
-		AssertEventsOkForState(events, wk);
+			/*
+			 * WAL keepers are only taken out of SS_OFFLINE by calls to
+			 * ResetConnection
+			 */
+		case SS_OFFLINE:
+			elog(FATAL, "Unexpected walkeeper %s:%s state advancement: is offline",
+					wk->host, wk->port);
+			break;			/* actually unreachable, but prevents
+							 * -Wimplicit-fallthrough */
 
-		/* Execute the code corresponding to the current state */
-		switch (wk->state)
-		{
-				/*
-				 * WAL keepers are only taken out of SS_OFFLINE by calls to
-				 * ResetConnection
-				 */
-			case SS_OFFLINE:
-				elog(FATAL, "Unexpected walkeeper %s:%s state advancement: is offline",
-					 wk->host, wk->port);
-				break;			/* actually unreachable, but prevents
-								 * -Wimplicit-fallthrough */
+			/*
+			 * Both connecting states run the same logic. The only
+			 * difference is the events they're expecting
+			 */
+		case SS_CONNECTING_READ:
+		case SS_CONNECTING_WRITE:
+			HandleConnectionEvent(wk);
+			break;
 
-				/*
-				 * Both connecting states run the same logic. The only
-				 * difference is the events they're expecting
-				 */
-			case SS_CONNECTING_READ:
-			case SS_CONNECTING_WRITE:
-				{
-					WalProposerConnectPollStatusType result = walprop_connect_poll(wk->conn);
+			/*
+			 * Waiting for a successful CopyBoth response.
+			 */
+		case SS_WAIT_EXEC_RESULT:
+			RecvStartWALPushResult(wk);
+			break;
 
-					/* The new set of events we'll wait on, after updating */
-					uint32		new_events = WL_NO_EVENTS;
+			/*
+			 * Finish handshake comms: receive information about the safekeeper.
+			 */
+		case SS_HANDSHAKE_RECV:
+			RecvAcceptorGreeting(wk);
+			break;
 
-					switch (result)
-					{
-						case WP_CONN_POLLING_OK:
-							elog(LOG, "connected with node %s:%s", wk->host,
-								 wk->port);
+			/*
+			 * Voting is an idle state - we don't expect any events to trigger.
+			 * Refer to the execution of SS_HANDSHAKE_RECV to see how nodes are
+			 * transferred from SS_VOTING to sending actual vote requests.
+			 */
+		case SS_VOTING:
+			elog(WARNING, "EOF from node %s:%s in %s state", wk->host,
+					wk->port, FormatWalKeeperState(wk->state));
+			ResetConnection(wk);
+			return;
 
-							/*
-							 * Once we're fully connected, we can move to the
-							 * next state
-							 */
-							wk->state = SS_EXEC_STARTWALPUSH;
-
-							/*
-							 * Even though SS_EXEC_STARTWALPUSH doesn't wait
-							 * on anything, we do need to replace the current
-							 * event, so we have to just pick something. We'll
-							 * eventually need the socket to be readable, so
-							 * we go with that.
-							 */
-							new_events = WL_SOCKET_READABLE;
-							break;
-
-							/*
-							 * If we need to poll to finish connecting,
-							 * continue doing that
-							 */
-						case WP_CONN_POLLING_READING:
-							wk->state = SS_CONNECTING_READ;
-							new_events = WL_SOCKET_READABLE;
-							break;
-						case WP_CONN_POLLING_WRITING:
-							wk->state = SS_CONNECTING_WRITE;
-							new_events = WL_SOCKET_WRITEABLE;
-							break;
-
-						case WP_CONN_POLLING_FAILED:
-							elog(WARNING, "Failed to connect to node '%s:%s': %s",
-								 wk->host, wk->port, walprop_error_message(wk->conn));
-
-							/*
-							 * If connecting failed, we don't want to restart
-							 * the connection because that might run us into a
-							 * loop. Instead, shut it down -- it'll naturally
-							 * restart at a slower interval on calls to
-							 * ReconnectWalKeepers.
-							 */
-							ShutdownConnection(wk);
-							return;
-					}
-
-					/*
-					 * Because PQconnectPoll can change the socket, we have to
-					 * un-register the old event and re-register an event on
-					 * the new socket.
-					 */
-					HackyRemoveWalProposerEvent(wk);
-					wk->eventPos = AddWaitEventToSet(waitEvents, new_events, walprop_socket(wk->conn), NULL, wk);
-					break;
-				}
-
-				/*
-				 * Send "START_WAL_PUSH" command to the walkeeper. After
-				 * sending, wait for response with SS_WAIT_EXEC_RESULT
-				 */
-			case SS_EXEC_STARTWALPUSH:
-				{
-					char *query = NULL;
-					if (zenith_pageserver_connstring_walproposer != NULL) {
-						query = psprintf("START_WAL_PUSH %s", zenith_pageserver_connstring_walproposer);
-					} else {
-						query = psprintf("START_WAL_PUSH");
-					}
-					if (!walprop_send_query(wk->conn, query))
-					{
-						pfree(query);
-						elog(WARNING, "Failed to send 'START_WAL_PUSH' query to walkeeper %s:%s: %s",
-							wk->host, wk->port, walprop_error_message(wk->conn));
-						ShutdownConnection(wk);
-						return;
-					}
-					pfree(query);
-					wk->state = SS_WAIT_EXEC_RESULT;
-					UpdateEventSet(wk, WL_SOCKET_READABLE);
-					break;
-				}
-
-			case SS_WAIT_EXEC_RESULT:
-				switch (walprop_get_query_result(wk->conn))
-				{
-						/*
-						 * Successful result, move on to starting the
-						 * handshake
-						 */
-					case WP_EXEC_SUCCESS_COPYBOTH:
-
-						/*
-						 * Because this state is immediately executable, we'll
-						 * start this on the next iteration of the loop
-						 */
-						wk->state = SS_HANDSHAKE_SEND;
-						break;
-
-						/*
-						 * Needs repeated calls to finish. Wait until the
-						 * socket is readable
-						 */
-					case WP_EXEC_NEEDS_INPUT:
-
-						/*
-						 * SS_WAIT_EXEC_RESULT is always reached through an
-						 * event, so we don't need to update the event set
-						 */
-						break;
-
-					case WP_EXEC_FAILED:
-						elog(WARNING, "Failed to send query to walkeeper %s:%s: %s",
-							 wk->host, wk->port, walprop_error_message(wk->conn));
-						ShutdownConnection(wk);
-						return;
-
-						/*
-						 * Unexpected result -- funamdentally an error, but we
-						 * want to produce a custom message, rather than a
-						 * generic "something went wrong"
-						 */
-					case WP_EXEC_UNEXPECTED_SUCCESS:
-						elog(WARNING, "Received bad response from walkeeper %s:%s query execution",
-							 wk->host, wk->port);
-						ShutdownConnection(wk);
-						return;
-				}
-				break;
-
-				/*
-				 * Start handshake: first of all send information about the
-				 * WAL keeper. After sending, we wait on SS_HANDSHAKE_RECV for
-				 * a response to finish the handshake.
-				 */
-			case SS_HANDSHAKE_SEND:
-
-				/*
-				 * On failure, logging & resetting the connection is handled.
-				 * We just need to handle the control flow.
-				 */
-				if (!BlockingWrite(i, &proposerGreeting, sizeof(proposerGreeting), SS_HANDSHAKE_RECV))
-					return;
-
-				break;
-
-				/*
-				 * Finish handshake comms: receive information about the WAL
-				 * keeper
-				 */
-			case SS_HANDSHAKE_RECV:
-
-				/*
-				 * If our reading doesn't immediately succeed, any necessary
-				 * error handling or state setting is taken care of. We can
-				 * leave any other work until later.
-				 */
-				if (!AsyncReadFixed(i, &wk->greet, sizeof(wk->greet)))
-					return;
-
-				/* Protocol is all good, move to voting. */
-				wk->state = SS_VOTING;
-
-				/*
-				 * Don't need to update the event set yet. Either we update
-				 * the event set to WL_SOCKET_READABLE *or* we change the
-				 * state to SS_SEND_VOTE in the loop below
-				 */
-				UpdateEventSet(wk, WL_SOCKET_READABLE);
-				wk->feedback.flushLsn = truncateLsn;
-				wk->feedback.hs.ts = 0;
-
-				/*
-				 * We want our term to be highest and unique, so choose max
-				 * and +1 once we have majority.
-				 */
-				propTerm = Max(walkeeper[i].greet.term, propTerm);
-
-				/*
-				 * Check if we have quorum. If there aren't enough walkeepers,
-				 * wait and do nothing. We'll eventually get a task when the
-				 * election starts.
-				 *
-				 * If we do have quorum, we can start an election
-				 */
-				if (++n_connected < quorum)
-				{
-					/*
-					 * SS_VOTING is an idle state; read-ready indicates the
-					 * connection closed.
-					 */
-					UpdateEventSet(wk, WL_SOCKET_READABLE);
-				}
-				else
-				{
-					if (n_connected == quorum)
-					{
-						propTerm++;
-						/* prepare voting message */
-						voteRequest = (VoteRequest)
-						{
-							.tag = 'v',
-								.term = propTerm
-						};
-						memcpy(voteRequest.proposerId.data, proposerGreeting.proposerId.data, UUID_LEN);
-					}
-
-					/*
-					 * Now send voting request to the cohort and wait
-					 * responses
-					 */
-					for (int j = 0; j < n_walkeepers; j++)
-					{
-						/*
-						 * Remember: SS_VOTING indicates that the walkeeper is
-						 * participating in voting, but hasn't sent anything
-						 * yet. The ones that have sent something are given
-						 * SS_SEND_VOTE or SS_WAIT_VERDICT.
-						 */
-						if (walkeeper[j].state == SS_VOTING)
-						{
-							walkeeper[j].state = SS_SEND_VOTE;
-							/* Immediately send info */
-							AdvancePollState(j, WL_NO_EVENTS);
-						}
-					}
-				}
-				break;
-
-				/*
-				 * Voting is an idle state - we don't expect any events to
-				 * trigger. Refer to the execution of SS_HANDSHAKE_RECV to see
-				 * how nodes are transferred from SS_VOTING to SS_SEND_VOTE.
-				 */
-			case SS_VOTING:
-				elog(WARNING, "EOF from node %s:%s in %s state", wk->host,
-					 wk->port, FormatWalKeeperState(wk->state));
-				ResetConnection(wk);
-				break;
-
-				/* We have quorum for voting, send our vote request */
-			case SS_SEND_VOTE:
-				elog(LOG, "requesting vote from %s:%s for term " UINT64_FORMAT, wk->host, wk->port, voteRequest.term);
-				/* On failure, logging & resetting is handled */
-				if (!BlockingWrite(i, &voteRequest, sizeof(voteRequest), SS_WAIT_VERDICT))
-					return;
-
-				/* If successful, wait for read-ready with SS_WAIT_VERDICT */
-				break;
-
-				/* Start reading the walkeeper response for our candidate */
-			case SS_WAIT_VERDICT:
-				wk->voteResponse.apm.tag = 'v';
-				if (!AsyncReadMessage(i, (AcceptorProposerMessage *) &wk->voteResponse))
-					return;
-
-				elog(LOG,
-					 "got VoteResponse from acceptor %s:%s, voteGiven=" UINT64_FORMAT ", epoch=" UINT64_FORMAT ", flushLsn=%X/%X, truncateLsn=%X/%X",
-					 wk->host, wk->port, wk->voteResponse.voteGiven, GetHighestTerm(&wk->voteResponse.termHistory),
-					 LSN_FORMAT_ARGS(wk->voteResponse.flushLsn),
-					 LSN_FORMAT_ARGS(wk->voteResponse.truncateLsn));
-
-				/*
-				 * In case of acceptor rejecting our vote, bail out, but only
-				 * if either it already lives in strictly higher term
-				 * (concurrent compute spotted) or we are not elected yet and
-				 * thus need the vote.
-				 */
-				if ((!wk->voteResponse.voteGiven) &&
-					(wk->voteResponse.term > propTerm || n_votes < quorum))
-				{
-					elog(FATAL, "WAL acceptor %s:%s with term " INT64_FORMAT " rejects our connection request with term " INT64_FORMAT "",
-						 wk->host, wk->port,
-						 wk->voteResponse.term, propTerm);
-				}
-				Assert(wk->voteResponse.term == propTerm);
-
-				/* Handshake completed, do we have quorum? */
-				n_votes++;
-				if (n_votes < quorum)
-				{
-					wk->state = SS_IDLE; /* can't do much yet, no quorum */
-				}
-				else if (n_votes > quorum)
-				{
-
-					/* recovery already performed, just start streaming */
-					SendProposerElected(wk);
-				}
-				else
-				{
-					wk->state = SS_IDLE;
-					UpdateEventSet(wk, WL_SOCKET_READABLE); /* Idle states wait for
-															 * read-ready */
-
-					DetermineEpochStartLsn();
-
-					/*
-					 * Check if not all safekeepers are up-to-date, we need to
-					 * download WAL needed to synchronize them
-					 */
-					if (truncateLsn < propEpochStartLsn)
-					{
-						elog(LOG,
-							 "start recovery because truncateLsn=%X/%X is not "
-							 "equal to epochStartLsn=%X/%X",
-							 LSN_FORMAT_ARGS(truncateLsn),
-							 LSN_FORMAT_ARGS(propEpochStartLsn));
-						/* Perform recovery */
-						if (!WalProposerRecovery(donor, proposerGreeting.timeline, truncateLsn, propEpochStartLsn))
-							elog(FATAL, "Failed to recover state");
-					}
-					else if (syncSafekeepers)
-					{
-						/* Sync is not needed: just exit */
-						fprintf(stdout, "%X/%X\n", LSN_FORMAT_ARGS(propEpochStartLsn));
-						exit(0);
-					}
-
-					for (int i = 0; i < n_walkeepers; i++)
-					{
-						if (walkeeper[i].state == SS_IDLE)
-							SendProposerElected(&walkeeper[i]);
-					}
-
-					/* 
-					 * The proposer has been elected, and there will be no quorum waiting
-					 * after this point. There will be no safekeeper with state SS_IDLE
-					 * also, because that state is used only for quorum waiting.
-					 */
-
-					if (syncSafekeepers)
-					{
-						/*
-						 * Queue empty message to enforce receiving feedback
-						 * even from nodes who are fully recovered; this is
-						 * required to learn they switched epoch which finishes
-						 * sync-safeekepers who doesn't generate any real new
-						 * records. Will go away once we switch to async acks.
-						 */
-						BroadcastMessage(CreateMessageCommitLsnOnly(propEpochStartLsn));
-
-						/* keep polling until all walkeepers are synced */
-						return;
-					}
-
-					WalProposerStartStreaming(propEpochStartLsn);
-					/* Should not return here */
-				}
-
-				break;
+			/* Read the safekeeper response for our candidate */
+		case SS_WAIT_VERDICT:
+			RecvVoteResponse(wk);
+			break;
 
 			/* Flush proposer announcement message */
-			case SS_SEND_ELECTED_FLUSH:
+		case SS_SEND_ELECTED_FLUSH:
 
-				/*
-				 * AsyncFlush ensures we only move on to SS_RECV_FEEDBACK once
-				 * the flush completes. If we still have more to do, we'll
-				 * wait until the next poll comes along.
-				 */
-				if (!AsyncFlush(wk))
+			/*
+			 * AsyncFlush ensures we only move on to SS_ACTIVE once the flush
+			 * completes. If we still have more to do, we'll wait until the next
+			 * poll comes along.
+			 */
+			if (!AsyncFlush(wk))
+				return;
+			
+			StartStreaming(wk);
+			break;
+
+			/*
+			 * Idle state for waiting votes from quorum.
+			 */
+		case SS_IDLE:
+			elog(WARNING, "EOF from node %s:%s in %s state", wk->host,
+					wk->port, FormatWalKeeperState(wk->state));
+			ResetConnection(wk);
+			return;
+
+			/*
+			 * Active state is used for streaming WAL and receiving feedback.
+			 */
+		case SS_ACTIVE:
+			if (events & WL_SOCKET_WRITEABLE)
+				if (!SendAppendRequests(wk))
 					return;
-				
-				StartStreaming(wk);
 
-				break;
+			if (events & WL_SOCKET_READABLE)
+				if (!RecvAppendResponses(wk))
+					return;
 
+			UpdateEventSet(wk, WL_SOCKET_READABLE | (wk->currMsg == NULL ? 0 : WL_SOCKET_WRITEABLE));
+			break;
+	}
+}
 
-				/*
-				 * Idle state for sending WAL. Moved out only by calls to
-				 * SendMessageToNode
-				 */
-			case SS_IDLE:
-				elog(WARNING, "EOF from node %s:%s in %s state", wk->host,
-					 wk->port, FormatWalKeeperState(wk->state));
-				ResetConnection(wk);
-				break;
+static void
+HandleConnectionEvent(WalKeeper *wk)
+{
+	WalProposerConnectPollStatusType result = walprop_connect_poll(wk->conn);
 
+	/* The new set of events we'll wait on, after updating */
+	uint32		new_events = WL_NO_EVENTS;
 
-			case SS_ACTIVE:
-				if (events & WL_SOCKET_WRITEABLE)
-					if (!SendAppendRequests(wk))
-						return;
+	switch (result)
+	{
+		case WP_CONN_POLLING_OK:
+			elog(LOG, "connected with node %s:%s", wk->host,
+					wk->port);
 
-				if (events & WL_SOCKET_READABLE)
-					if (!RecvAppendResponses(wk))
-						return;
+			/*
+			 * We have to pick some event to update event set.
+			 * We'll eventually need the socket to be readable,
+			 * so we go with that.
+			 */
+			new_events = WL_SOCKET_READABLE;
+			break;
 
-				UpdateEventSet(wk, WL_SOCKET_READABLE | (wk->currMsg == NULL ? 0 : WL_SOCKET_WRITEABLE));
-				break;
+			/*
+			 * If we need to poll to finish connecting,
+			 * continue doing that
+			 */
+		case WP_CONN_POLLING_READING:
+			wk->state = SS_CONNECTING_READ;
+			new_events = WL_SOCKET_READABLE;
+			break;
+		case WP_CONN_POLLING_WRITING:
+			wk->state = SS_CONNECTING_WRITE;
+			new_events = WL_SOCKET_WRITEABLE;
+			break;
+
+		case WP_CONN_POLLING_FAILED:
+			elog(WARNING, "Failed to connect to node '%s:%s': %s",
+					wk->host, wk->port, walprop_error_message(wk->conn));
+
+			/*
+			 * If connecting failed, we don't want to restart
+			 * the connection because that might run us into a
+			 * loop. Instead, shut it down -- it'll naturally
+			 * restart at a slower interval on calls to
+			 * ReconnectWalKeepers.
+			 */
+			ShutdownConnection(wk);
+			return;
+	}
+
+	/*
+	 * Because PQconnectPoll can change the socket, we have to
+	 * un-register the old event and re-register an event on
+	 * the new socket.
+	 */
+	HackyRemoveWalProposerEvent(wk);
+	wk->eventPos = AddWaitEventToSet(waitEvents, new_events, walprop_socket(wk->conn), NULL, wk);
+
+	/* If we successfully connected, send START_WAL_PUSH query */
+	if (result == WP_CONN_POLLING_OK)
+		SendStartWALPush(wk);
+}
+
+/*
+ * Send "START_WAL_PUSH" message as an empty query to the walkeeper. Performs
+ * a blocking send, then immediately moves to SS_WAIT_EXEC_RESULT. If something
+ * goes wrong, change state to SS_OFFLINE and shutdown the connection.
+ */
+static void
+SendStartWALPush(WalKeeper *wk)
+{
+	char *query = NULL;
+	if (zenith_pageserver_connstring_walproposer != NULL) {
+		query = psprintf("START_WAL_PUSH %s", zenith_pageserver_connstring_walproposer);
+	} else {
+		query = psprintf("START_WAL_PUSH");
+	}
+	if (!walprop_send_query(wk->conn, query))
+	{
+		pfree(query);
+		elog(WARNING, "Failed to send 'START_WAL_PUSH' query to walkeeper %s:%s: %s",
+			wk->host, wk->port, walprop_error_message(wk->conn));
+		ShutdownConnection(wk);
+		return;
+	}
+	pfree(query);
+	wk->state = SS_WAIT_EXEC_RESULT;
+	UpdateEventSet(wk, WL_SOCKET_READABLE);
+}
+
+static void
+RecvStartWALPushResult(WalKeeper *wk)
+{
+	switch (walprop_get_query_result(wk->conn))
+	{
+			/*
+			 * Successful result, move on to starting the
+			 * handshake
+			 */
+		case WP_EXEC_SUCCESS_COPYBOTH:
+
+			SendProposerGreeting(wk);
+			break;
+
+			/*
+			 * Needs repeated calls to finish. Wait until the
+			 * socket is readable
+			 */
+		case WP_EXEC_NEEDS_INPUT:
+
+			/*
+			 * SS_WAIT_EXEC_RESULT is always reached through an
+			 * event, so we don't need to update the event set
+			 */
+			break;
+
+		case WP_EXEC_FAILED:
+			elog(WARNING, "Failed to send query to walkeeper %s:%s: %s",
+					wk->host, wk->port, walprop_error_message(wk->conn));
+			ShutdownConnection(wk);
+			return;
+
+			/*
+			 * Unexpected result -- funamdentally an error, but we
+			 * want to produce a custom message, rather than a
+			 * generic "something went wrong"
+			 */
+		case WP_EXEC_UNEXPECTED_SUCCESS:
+			elog(WARNING, "Received bad response from walkeeper %s:%s query execution",
+					wk->host, wk->port);
+			ShutdownConnection(wk);
+			return;
+	}
+}
+
+/*
+ * Start handshake: first of all send information about the
+ * WAL keeper. After sending, we wait on SS_HANDSHAKE_RECV for
+ * a response to finish the handshake.
+ */
+static void
+SendProposerGreeting(WalKeeper *wk)
+{
+	/*
+	 * On failure, logging & resetting the connection is handled.
+	 * We just need to handle the control flow.
+	 */
+	BlockingWrite(wk, &proposerGreeting, sizeof(proposerGreeting), SS_HANDSHAKE_RECV);
+}
+
+static void
+RecvAcceptorGreeting(WalKeeper *wk)
+{
+	/*
+	 * If our reading doesn't immediately succeed, any necessary
+	 * error handling or state setting is taken care of. We can
+	 * leave any other work until later.
+	 */
+	if (!AsyncReadFixed(wk, &wk->greet, sizeof(wk->greet)))
+		return;
+
+	/* Protocol is all good, move to voting. */
+	wk->state = SS_VOTING;
+	wk->feedback.flushLsn = truncateLsn;
+	wk->feedback.hs.ts = 0;
+
+	/*
+	 * We want our term to be highest and unique, so choose max
+	 * and +1 once we have majority.
+	 */
+	propTerm = Max(wk->greet.term, propTerm);
+
+	/*
+	 * Check if we have quorum. If there aren't enough safekeepers,
+	 * wait and do nothing. We'll eventually get a task when the
+	 * election starts.
+	 *
+	 * If we do have quorum, we can start an election
+	 */
+	if (++n_connected < quorum)
+	{
+		/*
+		 * SS_VOTING is an idle state; read-ready indicates the
+		 * connection closed.
+		 */
+		UpdateEventSet(wk, WL_SOCKET_READABLE);
+	}
+	else
+	{
+		if (n_connected == quorum)
+		{
+			propTerm++;
+			/* prepare voting message */
+			voteRequest = (VoteRequest)
+			{
+				.tag = 'v',
+					.term = propTerm
+			};
+			memcpy(voteRequest.proposerId.data, proposerGreeting.proposerId.data, UUID_LEN);
 		}
 
 		/*
-		 * We've already done something for these events - don't attempt more
-		 * states than we need to.
+		 * Now send voting request to the cohort and wait
+		 * responses
 		 */
-		events = WL_NO_EVENTS;
+		for (int j = 0; j < n_walkeepers; j++)
+		{
+			/*
+			 * Remember: SS_VOTING indicates that the safekeeper is
+			 * participating in voting, but hasn't sent anything
+			 * yet.
+			 */
+			if (walkeeper[j].state == SS_VOTING)
+				SendVoteRequest(&walkeeper[j]);
+		}
 	}
+}
+
+static void
+SendVoteRequest(WalKeeper *wk)
+{
+	/* We have quorum for voting, send our vote request */
+	elog(LOG, "requesting vote from %s:%s for term " UINT64_FORMAT, wk->host, wk->port, voteRequest.term);
+	/* On failure, logging & resetting is handled */
+	if (!BlockingWrite(wk, &voteRequest, sizeof(voteRequest), SS_WAIT_VERDICT))
+		return;
+
+	/* If successful, wait for read-ready with SS_WAIT_VERDICT */
+}
+
+static void
+RecvVoteResponse(WalKeeper *wk)
+{
+	wk->voteResponse.apm.tag = 'v';
+	if (!AsyncReadMessage(wk, (AcceptorProposerMessage *) &wk->voteResponse))
+		return;
+
+	elog(LOG,
+			"got VoteResponse from acceptor %s:%s, voteGiven=" UINT64_FORMAT ", epoch=" UINT64_FORMAT ", flushLsn=%X/%X, truncateLsn=%X/%X",
+			wk->host, wk->port, wk->voteResponse.voteGiven, GetHighestTerm(&wk->voteResponse.termHistory),
+			LSN_FORMAT_ARGS(wk->voteResponse.flushLsn),
+			LSN_FORMAT_ARGS(wk->voteResponse.truncateLsn));
+
+	/*
+	 * In case of acceptor rejecting our vote, bail out, but only
+	 * if either it already lives in strictly higher term
+	 * (concurrent compute spotted) or we are not elected yet and
+	 * thus need the vote.
+	 */
+	if ((!wk->voteResponse.voteGiven) &&
+		(wk->voteResponse.term > propTerm || n_votes < quorum))
+	{
+		elog(FATAL, "WAL acceptor %s:%s with term " INT64_FORMAT " rejects our connection request with term " INT64_FORMAT "",
+				wk->host, wk->port,
+				wk->voteResponse.term, propTerm);
+	}
+	Assert(wk->voteResponse.term == propTerm);
+
+	/* Handshake completed, do we have quorum? */
+	n_votes++;
+	if (n_votes < quorum)
+	{
+		wk->state = SS_IDLE; /* can't do much yet, no quorum */
+	}
+	else if (n_votes > quorum)
+	{
+		/* recovery already performed, just start streaming */
+		SendProposerElected(wk);
+	}
+	else
+	{
+		wk->state = SS_IDLE;
+		UpdateEventSet(wk, WL_SOCKET_READABLE); /* Idle states wait for
+												 * read-ready */
+
+		HandleElectedProposer();
+	}
+}
+
+/*
+ * Called once a majority of acceptors have voted for us and current proposer
+ * has been elected.
+ * 
+ * Sends ProposerElected message to all acceptors in SS_IDLE state and starts
+ * replication from walsender.
+ */
+static void
+HandleElectedProposer(void)
+{
+	DetermineEpochStartLsn();
+
+	/*
+	 * Check if not all safekeepers are up-to-date, we need to
+	 * download WAL needed to synchronize them
+	 */
+	if (truncateLsn < propEpochStartLsn)
+	{
+		elog(LOG,
+				"start recovery because truncateLsn=%X/%X is not "
+				"equal to epochStartLsn=%X/%X",
+				LSN_FORMAT_ARGS(truncateLsn),
+				LSN_FORMAT_ARGS(propEpochStartLsn));
+		/* Perform recovery */
+		if (!WalProposerRecovery(donor, proposerGreeting.timeline, truncateLsn, propEpochStartLsn))
+			elog(FATAL, "Failed to recover state");
+	}
+	else if (syncSafekeepers)
+	{
+		/* Sync is not needed: just exit */
+		fprintf(stdout, "%X/%X\n", LSN_FORMAT_ARGS(propEpochStartLsn));
+		exit(0);
+	}
+
+	for (int i = 0; i < n_walkeepers; i++)
+	{
+		if (walkeeper[i].state == SS_IDLE)
+			SendProposerElected(&walkeeper[i]);
+	}
+
+	/* 
+	 * The proposer has been elected, and there will be no quorum waiting
+	 * after this point. There will be no safekeeper with state SS_IDLE
+	 * also, because that state is used only for quorum waiting.
+	 */
+
+	if (syncSafekeepers)
+	{
+		/*
+			* Queue empty message to enforce receiving feedback
+			* even from nodes who are fully recovered; this is
+			* required to learn they switched epoch which finishes
+			* sync-safeekepers who doesn't generate any real new
+			* records. Will go away once we switch to async acks.
+			*/
+		BroadcastMessage(CreateMessageCommitLsnOnly(propEpochStartLsn));
+
+		/* keep polling until all walkeepers are synced */
+		return;
+	}
+
+	WalProposerStartStreaming(propEpochStartLsn);
+	/* Should not return here */
 }
 
 /* latest term in TermHistory, or 0 is there is no entries */
@@ -1404,8 +1409,7 @@ StartStreaming(WalKeeper *wk)
 /*
  * Start sending message to the particular node.
  *
- * Always updates the state and event set for the WAL keeper; setting either of
- * these before calling would be redundant work.
+ * Can be used only for safekeepers in SS_ACTIVE state.
  */
 static void
 SendMessageToNode(int i, WalMessage *msg)
@@ -1414,6 +1418,7 @@ SendMessageToNode(int i, WalMessage *msg)
 
 	/* we shouldn't be already sending something */
 	Assert(wk->currMsg == NULL);
+	Assert(wk->state == SS_ACTIVE);
 
 	/*
 	 * Skip already acknowledged messages. Used after reconnection to get to
@@ -1649,7 +1654,7 @@ RecvAppendResponses(WalKeeper *wk)
 		 * necessary error handling or state setting is taken care
 		 * of. We can leave any other work until later.
 		 */
-		if (!AsyncReadFixed(wki, &wk->feedback, sizeof(wk->feedback)))
+		if (!AsyncReadFixed(wk, &wk->feedback, sizeof(wk->feedback)))
 			break;
 
 		Assert(wk->ackMsg != NULL && (wk->ackMsg->ackMask & (1 << wki)) == 0);
@@ -1911,10 +1916,8 @@ HandleWalKeeperResponse(void)
  * failure.
  */
 static bool
-AsyncRead(int i, char **buf, int *buf_size)
+AsyncRead(WalKeeper *wk, char **buf, int *buf_size)
 {
-	WalKeeper  *wk = &walkeeper[i];
-
 	switch (walprop_async_read(wk->conn, buf, buf_size))
 	{
 		case PG_ASYNC_READ_SUCCESS:
@@ -1944,13 +1947,12 @@ AsyncRead(int i, char **buf, int *buf_size)
  * failed, a warning is emitted and the connection is reset.
  */
 static bool
-AsyncReadFixed(int i, void *value, size_t value_size)
+AsyncReadFixed(WalKeeper *wk, void *value, size_t value_size)
 {
-	WalKeeper  *wk = &walkeeper[i];
 	char	   *buf = NULL;
 	int			buf_size = -1;
 
-	if (!(AsyncRead(i, &buf, &buf_size)))
+	if (!(AsyncRead(wk, &buf, &buf_size)))
 		return false;
 
 	/*
@@ -1977,15 +1979,14 @@ AsyncReadFixed(int i, void *value, size_t value_size)
  * TODO: migrate AsyncReadFixed here for all messages
  */
 static bool
-AsyncReadMessage(int i, AcceptorProposerMessage *anymsg)
+AsyncReadMessage(WalKeeper *wk, AcceptorProposerMessage *anymsg)
 {
-	WalKeeper  *wk = &walkeeper[i];
 	char *buf;
 	int buf_size;
 	uint64 tag;
 	StringInfoData s;
 
-	if (!(AsyncRead(i, &buf, &buf_size)))
+	if (!(AsyncRead(wk, &buf, &buf_size)))
 		return false;
 
 	/* parse it */
@@ -2038,9 +2039,8 @@ AsyncReadMessage(int i, AcceptorProposerMessage *anymsg)
  * single packet.
  */
 static bool
-BlockingWrite(int i, void *msg, size_t msg_size, WalKeeperState success_state)
+BlockingWrite(WalKeeper *wk, void *msg, size_t msg_size, WalKeeperState success_state)
 {
-	WalKeeper  *wk = &walkeeper[i];
 	uint32		events;
 
 	if (!walprop_blocking_write(wk->conn, msg, msg_size))

--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -1545,6 +1545,15 @@ HandleActiveState(WalKeeper *wk, uint32 events)
 		if (!RecvAppendResponses(wk))
 			return;
 
+	/*
+	 * We should wait for WL_SOCKET_WRITEABLE event if we have unflushed data
+	 * in the buffer.
+	 * 
+	 * wk->currMsg checks if we have pending unsent messages. This check isn't
+	 * necessary now, because we always send queue messages immediately after
+	 * creation. But it's good to have it here in case we change this behavior
+	 * in the future.
+	 */
 	if (wk->currMsg != NULL || wk->flushWrite)
 		newEvents |= WL_SOCKET_WRITEABLE;
 

--- a/src/backend/replication/walproposer_utils.c
+++ b/src/backend/replication/walproposer_utils.c
@@ -141,6 +141,9 @@ WalKeeperStateDesiredEvents(WalKeeperState state)
 		/* 
 		 * Flush states require write-ready for flushing.
 		 * Active state does both reading and writing.
+		 * 
+		 * TODO: SS_ACTIVE sometimes doesn't need to be write-ready. We should
+		 * 	check wk->flushWrite here to set WL_SOCKET_WRITEABLE.
 		 */
 		case SS_SEND_ELECTED_FLUSH:
 		case SS_ACTIVE:

--- a/src/backend/replication/walproposer_utils.c
+++ b/src/backend/replication/walproposer_utils.c
@@ -48,23 +48,14 @@ FormatWalKeeperState(WalKeeperState state)
 		case SS_CONNECTING_WRITE:
 			return_val = "connecting";
 			break;
-		case SS_EXEC_STARTWALPUSH:
-			return_val = "sending 'START_WAL_PUSH' query";
-			break;
 		case SS_WAIT_EXEC_RESULT:
 			return_val = "receiving query result";
-			break;
-		case SS_HANDSHAKE_SEND:
-			return_val = "handshake (sending)";
 			break;
 		case SS_HANDSHAKE_RECV:
 			return_val = "handshake (receiving)";
 			break;
 		case SS_VOTING:
 			return_val = "voting";
-			break;
-		case SS_SEND_VOTE:
-			return_val = "sending vote";
 			break;
 		case SS_WAIT_VERDICT:
 			return_val = "wait-for-verdict";
@@ -140,24 +131,20 @@ WalKeeperStateDesiredEvents(WalKeeperState state)
 			result = WL_SOCKET_READABLE;
 			break;
 
-		/* Most writing states don't require any socket conditions */
-		case SS_EXEC_STARTWALPUSH:
-		case SS_HANDSHAKE_SEND:
-		case SS_SEND_VOTE:
-			result = WL_NO_EVENTS;
-			break;
-		/* but flushing does require read- or write-ready */
-		case SS_SEND_ELECTED_FLUSH:
-		/* Active state does both reading and writing to the socket */
-		case SS_ACTIVE:
-			result = WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE;
-			break;
-
 		/* Idle states use read-readiness as a sign that the connection has been
 		 * disconnected. */
 		case SS_VOTING:
 		case SS_IDLE:
 			result = WL_SOCKET_READABLE;
+			break;
+
+		/* 
+		 * Flush states require write-ready for flushing.
+		 * Active state does both reading and writing.
+		 */
+		case SS_SEND_ELECTED_FLUSH:
+		case SS_ACTIVE:
+			result = WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE;
 			break;
 
 		/* The offline state expects no events. */
@@ -167,16 +154,6 @@ WalKeeperStateDesiredEvents(WalKeeperState state)
 	}
 
 	return result;
-}
-
-/* Returns whether the WAL keeper state corresponds to something that should be
- * immediately executed -- i.e. it is not idle, and is not currently waiting. */
-bool
-StateShouldImmediatelyExecute(WalKeeperState state)
-{
-	/* This is actually pretty simple to determine. */
-	return WalKeeperStateDesiredEvents(state) == WL_NO_EVENTS
-		&& state != SS_OFFLINE;
 }
 
 /* Returns a human-readable string corresponding to the event set

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -68,20 +68,12 @@ typedef enum
 } PGAsyncWriteResult;
 
 /*
- * WAL safekeeper state
+ * WAL safekeeper state, which is used to wait for some event.
  *
  * States are listed here in the order that they're executed.
  *
  * Most states, upon failure, will move back to SS_OFFLINE by calls to
  * ResetConnection or ShutdownConnection.
- *
- * Also note: In places we say that a state "immediately" moves to another. This
- * happens in states that only exist to execute program logic, so they run
- * exactly once (when moved into), without waiting for any socket conditions.
- *
- * For example, when we set a WalKeeper's state to SS_SEND_VOTE, we immediately
- * call AdvancePollState - during which the WalKeeper switches its state to
- * SS_WAIT_VERDICT.
  */
 typedef enum
 {
@@ -99,28 +91,18 @@ typedef enum
 	 * they execute when polled, but we have this distinction in order to
 	 * recreate the event set in HackyRemoveWalProposerEvent.
 	 *
-	 * After the connection is made, moves to SS_EXEC_STARTWALPUSH.
+	 * After the connection is made, "START_WAL_PUSH" query is sent.
 	 */
 	SS_CONNECTING_WRITE,
 	SS_CONNECTING_READ,
 
 	/*
-	 * Sending the "START_WAL_PUSH" message as an empty query to the walkeeper.
-	 * Performs a blocking send, then immediately moves to SS_WAIT_EXEC_RESULT.
-	 */
-	SS_EXEC_STARTWALPUSH,
-	/*
 	 * Waiting for the result of the "START_WAL_PUSH" command.
 	 *
-	 * After we get a successful result, moves to SS_HANDSHAKE_SEND.
+	 * After we get a successful result, sends handshake to safekeeper.
 	 */
 	SS_WAIT_EXEC_RESULT,
 
-	/*
-	 * Executing the sending half of the handshake. Performs the blocking send,
-	 * then immediately moves to SS_HANDSHAKE_RECV.
-	 */
-	SS_HANDSHAKE_SEND,
 	/*
 	 * Executing the receiving half of the handshake. After receiving, moves to
 	 * SS_VOTING.
@@ -128,32 +110,28 @@ typedef enum
 	SS_HANDSHAKE_RECV,
 
 	/*
-	 * Currently participating in voting, but a quorum hasn't yet been reached.
+	 * Waiting to participate in voting, but a quorum hasn't yet been reached.
 	 * This is an idle state - we do not expect AdvancePollState to be called.
 	 *
-	 * Moved externally to SS_SEND_VOTE or SS_WAIT_VERDICT by execution of
-	 * SS_HANDSHAKE_RECV.
+	 * Moved externally by execution of SS_HANDSHAKE_RECV, when we received a
+	 * quorum of handshakes.
 	 */
 	SS_VOTING,
-	/*
-	 * Performs a blocking send of the assigned vote, then immediately moves to
-	 * SS_WAIT_VERDICT.
-	 */
-	SS_SEND_VOTE,
+
 	/*
 	 * Already sent voting information, waiting to receive confirmation from the
-	 * node. After receiving, moves to SS_IDLE.
+	 * node. After receiving, moves to SS_IDLE, if the quorum isn't reached yet.
 	 */
 	SS_WAIT_VERDICT,
 
-	/* need to flush ProposerAnnouncement */
+	/* Need to flush ProposerElected message. */
 	SS_SEND_ELECTED_FLUSH,
 
 	/*
 	 * Waiting for quorum to send WAL. Idle state. If the socket becomes
 	 * read-ready, the connection has been closed.
 	 *
-	 * Moves to SS_ACTIVE only by calls to SendMessageToNode.
+	 * Moves to SS_ACTIVE only by call to StartStreaming.
 	 */
 	SS_IDLE,
 
@@ -361,7 +339,6 @@ int        CompareLsn(const void *a, const void *b);
 char*      FormatWalKeeperState(WalKeeperState state);
 void       AssertEventsOkForState(uint32 events, WalKeeper* wk);
 uint32     WalKeeperStateDesiredEvents(WalKeeperState state);
-bool       StateShouldImmediatelyExecute(WalKeeperState state);
 char*      FormatEvents(uint32 events);
 void       WalProposerMain(Datum main_arg);
 void       WalProposerBroadcast(XLogRecPtr startpos, char* data, int len);

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -173,7 +173,7 @@ typedef struct AcceptorProposerMessage
  */
 typedef struct AcceptorGreeting
 {
-	uint64		tag;
+	AcceptorProposerMessage apm;
 	term_t		term;
 } AcceptorGreeting;
 
@@ -284,11 +284,11 @@ typedef struct HotStandbyFeedback
  */
 typedef struct AppendResponse
 {
+	AcceptorProposerMessage apm;
 	/*
 	 * Current term of the safekeeper; if it is higher than proposer's, the
 	 * compute is out of date.
 	 */
-	uint64 tag;
 	term_t     term;
 	// TODO: add comment
 	XLogRecPtr flushLsn;

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -319,8 +319,8 @@ typedef struct WalKeeper
 	WalProposerConn*   conn;
 	StringInfoData outbuf;
 
-	bool               flushWrite;    /* set to true if we wrote currMsg, but still need to call AsyncFlush */
-	WalMessage*        currMsg;       /* message been send to the receiver */
+	bool               flushWrite;    /* set to true if we need to call AsyncFlush, to flush pending messages */
+	WalMessage*        currMsg;       /* message that wasn't sent yet or NULL, if we have nothing to send */
 	WalMessage*        ackMsg;        /* message waiting ack from the receiver */
 
 	int                eventPos;      /* position in wait event set. Equal to -1 if no event */


### PR DESCRIPTION
Closes https://github.com/zenithdb/zenith/issues/1041


- [X] Leave only states in which we wait, others can be executed directly or in a function
- [X] Remove loop in AdvancePollState
- [X] Migrate AsyncReadFixed to AsyncReadMessage
- [ ] Once connection is established, do UpdateEventSet only when we need to flush (set WL_SOCKET_WRITEABLE) or when flush is done (unset it).
- [X] Optimize UpdateEventSet calls
