### PR TITLE
Change the unit of cluster size limit GUC to MB, and other fixes.

### DIFF
--- a/contrib/zenith/libpagestore.c
+++ b/contrib/zenith/libpagestore.c
@@ -339,9 +339,9 @@ _PG_init(void)
 							"cluster size limit",
 							NULL,
 							&max_cluster_size,
-							-1, -1, MAX_KILOBYTES,
+							-1, -1, INT_MAX,
 							PGC_SIGHUP,
-							GUC_UNIT_BYTE,
+							GUC_UNIT_MB,
 							NULL, NULL,	NULL);
 
 	relsize_hash_init();


### PR DESCRIPTION
The GUC is a 32-bit integer, so if the base unit is bytes, the max
limit you can set is only 2 GB. Furthermore, the web console assumed
that the unit is in MB, and set it to 10000 meaning 10 GB, but in
reality it was set to just 10 kB.

Remove the WARNINGs related to cluster size limit. That was probably
supposed to be DEBUG5 or something, because it's extremely noisy
currently. You get the WARNING for *every block* when a relation is
extended.

Some kind of a WARNING when you approach the limit would make sense,
but it's difficult to do in a sensible way with WARNINGs from the
server. Firstly, most applications will ignore WARNINGs, in which case
they don't accomplish anything. If an application forwards them to the
user, that's not great either unless the application user happens to
be the DBA. If you're lucky, the WARNINGs end up in an application log
and the DBA is alerted, but printing the message for every relation
extension is too noisy for that too. An email alert would probably be
best, outside Postgres.

Also don't enforce the limit when extending a temporary or unlogged
relation. They don't count towards the cluster size limit, so it seems
weird to error out on them. And reword the error message a bit.