### PR TITLE
Revert "Use local relation cache for smgr_exists"

### DIFF
--- a/contrib/zenith/pagestore_smgr.c
+++ b/contrib/zenith/pagestore_smgr.c
@@ -618,7 +618,6 @@ zenith_exists(SMgrRelation reln, ForkNumber forkNum)
 {
 	bool		exists;
 	ZenithResponse *resp;
-	BlockNumber n_blocks;
 	bool		latest;
 	XLogRecPtr	request_lsn;
 
@@ -643,11 +642,6 @@ zenith_exists(SMgrRelation reln, ForkNumber forkNum)
 
 		default:
 			elog(ERROR, "unknown relpersistence '%c'", reln->smgr_relpersistence);
-	}
-
-	if (get_cached_relsize(reln->smgr_rnode.node, forkNum, &n_blocks))
-	{
-		return true;
 	}
 
 	request_lsn = zenith_get_request_lsn(&latest);
@@ -754,9 +748,6 @@ zenith_unlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo)
 	 * exist.
 	 */
 	mdunlink(rnode, forkNum, isRedo);
-	if (!RelFileNodeBackendIsTemp(rnode)) {
-		forget_cached_relsize(rnode.node, forkNum);
-	}
 }
 
 /*


### PR DESCRIPTION
This reverts commit 45dd8911ec13fd47882685f6d81d7b73696e1b84.

It introduced stable test_isolation failure. There was an idea that adding
strict backpressure settings would help, as absense of this commit could behave
as natural backpressure, but that didn't help. No better fix is immediately
available, so let's revert until sorting this out.

ref https://github.com/zenithdb/zenith/issues/1238
ref https://github.com/zenithdb/zenith/pull/1239