### PR TITLE
Expose reading a relation page at a specific LSN

### DIFF
--- a/contrib/zenith/pagestore_client.h
+++ b/contrib/zenith/pagestore_client.h
@@ -156,6 +156,10 @@ extern bool zenith_prefetch(SMgrRelation reln, ForkNumber forknum,
 							BlockNumber blocknum);
 extern void zenith_read(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 						char *buffer);
+
+extern void zenith_read_at_lsn(SMgrRelation reln, ForkNumber forkNum, BlockNumber blkno,
+			XLogRecPtr request_lsn, bool request_latest, char *buffer);
+
 extern void zenith_write(SMgrRelation reln, ForkNumber forknum,
 						 BlockNumber blocknum, char *buffer, bool skipFsync);
 extern void zenith_writeback(SMgrRelation reln, ForkNumber forknum,

--- a/contrib/zenith/pagestore_client.h
+++ b/contrib/zenith/pagestore_client.h
@@ -157,7 +157,7 @@ extern bool zenith_prefetch(SMgrRelation reln, ForkNumber forknum,
 extern void zenith_read(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 						char *buffer);
 
-extern void zenith_read_at_lsn(SMgrRelation reln, ForkNumber forkNum, BlockNumber blkno,
+extern void zenith_read_at_lsn(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno,
 			XLogRecPtr request_lsn, bool request_latest, char *buffer);
 
 extern void zenith_write(SMgrRelation reln, ForkNumber forknum,

--- a/contrib/zenith_test_utils/zenith_test_utils--1.0.sql
+++ b/contrib/zenith_test_utils/zenith_test_utils--1.0.sql
@@ -13,8 +13,12 @@ AS 'MODULE_PATHNAME', 'clear_buffer_cache'
 LANGUAGE C STRICT
 PARALLEL UNSAFE;
 
-CREATE FUNCTION get_raw_page_at_lsn(text, text, int8, pg_lsn)
+CREATE FUNCTION get_raw_page_at_lsn(relname text, forkname text, blocknum int8, lsn pg_lsn)
 RETURNS bytea
 AS 'MODULE_PATHNAME', 'get_raw_page_at_lsn'
-LANGUAGE C STRICT
-PARALLEL UNSAFE;
+LANGUAGE C PARALLEL UNSAFE;
+
+CREATE FUNCTION get_raw_page_at_lsn(tbspc oid, db oid, relfilenode oid, forknum int8, blocknum int8, lsn pg_lsn)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'get_raw_page_at_lsn_ex'
+LANGUAGE C PARALLEL UNSAFE;

--- a/contrib/zenith_test_utils/zenith_test_utils--1.0.sql
+++ b/contrib/zenith_test_utils/zenith_test_utils--1.0.sql
@@ -12,3 +12,9 @@ RETURNS VOID
 AS 'MODULE_PATHNAME', 'clear_buffer_cache'
 LANGUAGE C STRICT
 PARALLEL UNSAFE;
+
+CREATE FUNCTION get_raw_page_at_lsn(text, text, int8, pg_lsn)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'get_raw_page_at_lsn'
+LANGUAGE C STRICT
+PARALLEL UNSAFE;

--- a/contrib/zenith_test_utils/zenithtest.c
+++ b/contrib/zenith_test_utils/zenithtest.c
@@ -9,17 +9,29 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
-#include "fmgr.h"
 
 #include "access/xact.h"
+#include "access/relation.h"
+#include "catalog/namespace.h"
+#include "fmgr.h"
+#include "funcapi.h"
+#include "miscadmin.h"
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
+#include "utils/builtins.h"
+#include "utils/rel.h"
+#include "utils/varlena.h"
 
 
 PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(test_consume_xids);
 PG_FUNCTION_INFO_V1(clear_buffer_cache);
+PG_FUNCTION_INFO_V1(get_raw_page_at_lsn);
+
+
+extern void zenith_read_at_lsn(SMgrRelation reln, ForkNumber forkNum, BlockNumber blkno,
+			XLogRecPtr request_lsn, bool request_latest, char *buffer);
 
 /*
  * test_consume_xids(int4), for rapidly consuming XIDs, to test wraparound.
@@ -116,4 +128,88 @@ clear_buffer_cache(PG_FUNCTION_ARGS)
 	PG_END_TRY();
 
 	PG_RETURN_VOID();
+}
+
+
+/*
+ * A version to read page for at a specific LSN
+ */
+Datum
+get_raw_page_at_lsn(PG_FUNCTION_ARGS)
+{
+	text	   *relname = PG_GETARG_TEXT_PP(0);
+	text	   *forkname = PG_GETARG_TEXT_PP(1);
+	uint32		blkno = PG_GETARG_UINT32(2);
+	uint64 read_lsn = PG_GETARG_INT64(3);
+
+	bytea	   *raw_page;
+	ForkNumber	forknum;
+	RangeVar   *relrv;
+	Relation	rel;
+	char	   *raw_page_data;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to use raw page functions")));
+
+	relrv = makeRangeVarFromNameList(textToQualifiedNameList(relname));
+	rel = relation_openrv(relrv, AccessShareLock);
+
+	/* Check that this relation has storage */
+	if (rel->rd_rel->relkind == RELKIND_VIEW)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("cannot get raw page from view \"%s\"",
+						RelationGetRelationName(rel))));
+	if (rel->rd_rel->relkind == RELKIND_COMPOSITE_TYPE)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("cannot get raw page from composite type \"%s\"",
+						RelationGetRelationName(rel))));
+	if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("cannot get raw page from foreign table \"%s\"",
+						RelationGetRelationName(rel))));
+	if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("cannot get raw page from partitioned table \"%s\"",
+						RelationGetRelationName(rel))));
+	if (rel->rd_rel->relkind == RELKIND_PARTITIONED_INDEX)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("cannot get raw page from partitioned index \"%s\"",
+						RelationGetRelationName(rel))));
+
+	/*
+	 * Reject attempts to read non-local temporary relations; we would be
+	 * likely to get wrong data since we have no visibility into the owning
+	 * session's local buffers.
+	 */
+	if (RELATION_IS_OTHER_TEMP(rel))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot access temporary tables of other sessions")));
+
+
+	forknum = forkname_to_number(text_to_cstring(forkname));
+
+	if (blkno >= RelationGetNumberOfBlocksInFork(rel, forknum))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("block number %u is out of range for relation \"%s\"",
+						blkno, RelationGetRelationName(rel))));
+
+	/* Initialize buffer to copy to */
+	raw_page = (bytea *) palloc(BLCKSZ + VARHDRSZ);
+	SET_VARSIZE(raw_page, BLCKSZ + VARHDRSZ);
+	raw_page_data = VARDATA(raw_page);
+
+	zenith_read_at_lsn(rel->rd_smgr, forknum, blkno, read_lsn, false /* request_latest */, raw_page_data);
+
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_BYTEA_P(raw_page);
 }


### PR DESCRIPTION
allow reading older version of the page, currently for test and development only.
Reads are not cached by the Postgres buffer cache which make it safe.

The functionality is limited to relation pages and meant to work along with page inspect (although some page inspect functions work directly on relname-block input) 


Note: read LSN is not captured globally (which could result in a race between GC and read requests), this should be addressed in https://github.com/zenithdb/zenith/issues/1277

usage example:

```
create extension pageinspect;
create extension zenith_test_utils;

create table foo (c int);
insert into foo values (1);

select * from page_header(get_raw_page('foo', 'main', 0));
-- example output
--     lsn    | checksum | flags | lower | upper | special | pagesize | version | prune_xid
-- -----------+----------+-------+-------+-------+---------+----------+---------+-----------
--  0/16BBC88 |        0 |     0 |    28 |  8160 |    8192 |     8192 |       4 |         0

insert into foo values (2);

select * from page_header(get_raw_page('foo'::text, 'main'::text, 0));
--     lsn    | checksum | flags | lower | upper | special | pagesize | version | prune_xid
-- -----------+----------+-------+-------+-------+---------+----------+---------+-----------
--  0/17216C0 |        0 |     0 |    32 |  8128 |    8192 |     8192 |       4 |         0


select * from page_header(get_raw_page_at_lsn('foo'::text, 'main'::text, 0, '0/16BBC88'));
--     lsn    | checksum | flags | lower | upper | special | pagesize | version | prune_xid
-- -----------+----------+-------+-------+-------+---------+----------+---------+-----------
--  0/16BBC88 |        0 |     0 |    28 |  8160 |    8192 |     8192 |       4 |         0

```