### PR TITLE
Count WAL flushes in walreceiver

### DIFF
--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -495,6 +495,13 @@ WalReceiverMain(void)
 					break;
 
 				/*
+				 * Update WAL statistics, which are produced inside
+				 * issue_xlog_fsync function. This is useful for counting
+				 * WAL flushes, by querying pg_stat_wal.
+				 */
+				pgstat_send_wal(true);
+
+				/*
 				 * Ideally we would reuse a WaitEventSet object repeatedly
 				 * here to avoid the overheads of WaitLatchOrSocket on epoll
 				 * systems, but we can't be sure that libpq (or any other


### PR DESCRIPTION
issue_xlog_fsync updates WalStats internally, but doesn't propagate it.

Stats can be accessed by querying `SELECT wal_sync, wal_sync_time FROM pg_stat_wal` on the replica. This is useful for comparing fsyncs between vanilla synchronous replication and safekeepers.